### PR TITLE
Fix bug where segmenting was done twice and produced two of every segment

### DIFF
--- a/backend/data/data_filter.py
+++ b/backend/data/data_filter.py
@@ -11,7 +11,7 @@ def production_data_filter(file_name):
     data = json.load(open(file_name))
     out_data = []
 
-    for feature in data['features']:
+    for feature in data["features"]:
         properties = feature["properties"]
         # Format the time string to "YYYY-MM-DDThh:mm:ss" format
         time = properties["time"].replace("/", "-")

--- a/backend/data/example_create_test_prod_data.py
+++ b/backend/data/example_create_test_prod_data.py
@@ -9,8 +9,8 @@ API_password = os.environ["API_PASSWORD"]
 
 
 def data_in():
-    url = 'http://localhost:8000/api/prod-data/'
-    prod_data_path = '../Driftsdata_SubSet_Small.geojson'
+    url = "http://localhost:8000/api/prod-data/"
+    prod_data_path = "../Driftsdata_SubSet_Small.geojson"
     data = data_filter.production_data_filter(os.path.join(os.path.dirname(os.path.realpath(__file__)), prod_data_path))
 
     # Choose a sequence from data
@@ -21,5 +21,5 @@ def data_in():
     print("Status: {}\n{}".format(r.status_code, r.text))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     data_in()

--- a/backend/data/road_segmenting/calculate_distance.py
+++ b/backend/data/road_segmenting/calculate_distance.py
@@ -61,7 +61,7 @@ def calculate_road_length(point_list, max_length_meter, haversine):
     for i in range(1, len(point_list)):
         prev = i - 1
         if haversine:
-            coordinates = utm_to_latlon(point_list[i], point_list[prev], 32, 'V')
+            coordinates = utm_to_latlon(point_list[i], point_list[prev], 32, "V")
             length += haversine_formula(coordinates[0], coordinates[1])
         else:
             length += distance_formula(point_list[prev], point_list[i])

--- a/backend/data/road_segmenting/example_roadnet_to_db.py
+++ b/backend/data/road_segmenting/example_roadnet_to_db.py
@@ -4,7 +4,7 @@ import requests
 from road_segmenter import road_segmenter
 
 municipality = 5001
-type_of_road = 'kg'
+type_of_road = "kg"
 max_distance = 100
 min_segments = 2
 
@@ -20,25 +20,25 @@ def filter_road(road):
     :return: A filtered dict with the road segment
     """
     # Format the linestring correctly
-    linestring = ''
-    for pair in road['geometry']['coordinates']:
-        linestring += str(pair[0]) + ' ' + str(pair[1]) + ','
-    linestring = linestring.rstrip(',')
-    geometry = 'SRID={};LINESTRING({})'.format(road['properties']['geometri']['srid'], linestring)
+    linestring = ""
+    for pair in road["geometry"]["coordinates"]:
+        linestring += str(pair[0]) + " " + str(pair[1]) + ","
+    linestring = linestring.rstrip(",")
+    geometry = "SRID={};LINESTRING({})".format(road["properties"]["geometri"]["srid"], linestring)
 
     filtered_road = {
-        'the_geom':        geometry,
-        'county':          road['properties']['fylke'],
-        'href':            road['properties']['href'],
-        'category':        road['properties']['kategori'],
-        'municipality':    road['properties']['kommune'],
-        'startdate':       road['properties']['metadata']['startdato'],
-        'region':          road['properties']['region'],
-        'status':          road['properties']['status'],
-        'stretchdistance': road['properties']['strekningslengde'],
-        'typeofroad':      road['properties']['typeVeg'],
-        'roadsectionid':   road['properties']['veglenkeid'],
-        'vrefshortform':   road['properties']['vrefkortform'],
+        "the_geom":        geometry,
+        "county":          road["properties"]["fylke"],
+        "href":            road["properties"]["href"],
+        "category":        road["properties"]["kategori"],
+        "municipality":    road["properties"]["kommune"],
+        "startdate":       road["properties"]["metadata"]["startdato"],
+        "region":          road["properties"]["region"],
+        "status":          road["properties"]["status"],
+        "stretchdistance": road["properties"]["strekningslengde"],
+        "typeofroad":      road["properties"]["typeVeg"],
+        "roadsectionid":   road["properties"]["veglenkeid"],
+        "vrefshortform":   road["properties"]["vrefkortform"],
     }
 
     return filtered_road
@@ -60,12 +60,12 @@ def data_in(municipality, type_road, max_distance, min_segments):
     """
     :return: The status code of the finished post request.
     """
-    url = 'http://localhost:8000/api/roadsegments/'
+    url = "http://localhost:8000/api/roadsegments/"
     filtered_network = format_to_db(municipality, type_road, max_distance, min_segments)
 
     r = requests.post(url, json=filtered_network, auth=(API_username, API_password))
     return "Status: {}\n{}".format(r.status_code, r.text)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     print(data_in(municipality, type_of_road, max_distance, min_segments))

--- a/backend/data/road_segmenting/road_fetcher.py
+++ b/backend/data/road_segmenting/road_fetcher.py
@@ -17,13 +17,13 @@ def format_vegnet(kommune, vegref):
     counter = 0
 
     vegnett = NvdbVegnett()
-    vegnett.addfilter_geo({'kommune': int(kommune), 'vegreferanse': str(vegref)})
+    vegnett.addfilter_geo({"kommune": int(kommune), "vegreferanse": str(vegref)})
     veg = vegnett.nesteForekomst()
     while veg:
         raw_road_network.append(remove_keys(veg))
         counter += 1
         veg = vegnett.nesteForekomst()
-    formated_road_network = json.dumps(raw_road_network, sort_keys=True, indent=2, separators=(',', ':'))
+    formated_road_network = json.dumps(raw_road_network, sort_keys=True, indent=2, separators=(",", ":"))
     return counter, raw_road_network, formated_road_network
 
 
@@ -35,10 +35,10 @@ def vegnet_to_geojson(kommune, vegref):
     formated_geojson - formated geojson readibly by the human mind(duh)
     """
     v = NvdbVegnett()
-    v.addfilter_geo({'kommune': int(kommune), 'vegreferanse': str(vegref)})
+    v.addfilter_geo({"kommune": int(kommune), "vegreferanse": str(vegref)})
     raw_geojson, counter = vegnett2geojson(v)
     raw_geojson = remove_height(raw_geojson)
-    formatted_geojson = json.dumps(raw_geojson, sort_keys=True, indent=2, separators=(',', ':'))
+    formatted_geojson = json.dumps(raw_geojson, sort_keys=True, indent=2, separators=(",", ":"))
     return counter, raw_geojson, formatted_geojson
 
 
@@ -48,5 +48,5 @@ def road_network_to_file(filename, road_network):
     :param road_network: Unformatted geojson road network or raw_road_network
     :return: Nothing. Produces a file
     """
-    with open(filename, 'w') as outfile:
-        json.dump(road_network, outfile, sort_keys=True, indent=2, separators=(',', ':'))
+    with open(filename, "w") as outfile:
+        json.dump(road_network, outfile, sort_keys=True, indent=2, separators=(",", ":"))

--- a/backend/data/road_segmenting/road_filter.py
+++ b/backend/data/road_segmenting/road_filter.py
@@ -5,13 +5,13 @@ def remove_keys(road):
     :return: The same road segment without "felt" and "kvalitet".
     """
     road.pop("felt", None)
-    road['geometri'].pop("kvalitet", None)
+    road["geometri"].pop("kvalitet", None)
     return road
 
 
 def remove_height(road_network):
-    for road in road_network['features']:
-        for list_coordinates in road['geometry']['coordinates']:
+    for road in road_network["features"]:
+        for list_coordinates in road["geometry"]["coordinates"]:
             if len(list_coordinates) > 2:
                 del list_coordinates[2]
     return road_network

--- a/backend/data/road_segmenting/road_segmenter.py
+++ b/backend/data/road_segmenting/road_segmenter.py
@@ -80,16 +80,14 @@ def segment_network(road_network, len_road_network, max_distance, min_gps):
     :return: The segmented road network
     """
     segmented_road_network = []
-    for key, values in road_network.items():
-        if key != 'crs':
-            for road_segment in range(0, len_road_network):
-                if len(road_network['features'][road_segment]['geometry']['coordinates']) > min_gps:
-                    if check_split(road_network['features'][road_segment], max_distance):
-                        split_roads = split_segment(road_network['features'][road_segment],
-                                                    max_distance, [], min_gps)
-                        if split_roads is not None:
-                            for new_road in split_roads:
-                                segmented_road_network.append(new_road)
-                    else:
-                        segmented_road_network.append(road_network['features'][road_segment])
+    for road_segment in range(0, len_road_network):
+        if len(road_network['features'][road_segment]['geometry']['coordinates']) > min_gps:
+            if check_split(road_network['features'][road_segment], max_distance):
+                split_roads = split_segment(road_network['features'][road_segment],
+                                            max_distance, [], min_gps)
+                if split_roads is not None:
+                    for new_road in split_roads:
+                        segmented_road_network.append(new_road)
+            else:
+                segmented_road_network.append(road_network['features'][road_segment])
     return segmented_road_network

--- a/backend/data/road_segmenting/road_segmenter.py
+++ b/backend/data/road_segmenting/road_segmenter.py
@@ -13,32 +13,32 @@ def split_segment(road_segment, max_distance, segmented_road_network, min_gps):
     :param min_gps: Minimum amount of GPS points in a segment
     :return: Final compiled list of all segmented_road_network after being passed down recursively
     """
-    coordinates = road_segment['geometry']['coordinates']
+    coordinates = road_segment["geometry"]["coordinates"]
     index, meter = (calculate_road_length(coordinates, max_distance, False))
 
     segment_before_split = copy.deepcopy(road_segment)
-    segment_before_split['geometry']['coordinates'] = segment_before_split['geometry']['coordinates'][:index]
-    segment_before_split['properties']['strekningslengde'] = calculate_road_length_simple(
-        segment_before_split['geometry']['coordinates'])
+    segment_before_split["geometry"]["coordinates"] = segment_before_split["geometry"]["coordinates"][:index]
+    segment_before_split["properties"]["strekningslengde"] = calculate_road_length_simple(
+        segment_before_split["geometry"]["coordinates"])
 
     segment_after_split = copy.deepcopy(road_segment)
-    segment_after_split['geometry']['coordinates'] = segment_after_split['geometry']['coordinates'][index-1:]
-    segment_after_split['properties']['strekningslengde'] = calculate_road_length_simple(
-        segment_after_split['geometry']['coordinates'])
+    segment_after_split["geometry"]["coordinates"] = segment_after_split["geometry"]["coordinates"][index-1:]
+    segment_after_split["properties"]["strekningslengde"] = calculate_road_length_simple(
+        segment_after_split["geometry"]["coordinates"])
 
-    if len(segment_before_split['geometry']['coordinates']) >= min_gps:
+    if len(segment_before_split["geometry"]["coordinates"]) >= min_gps:
         segmented_road_network.append(segment_before_split)
     else:
         segmented_road_network.append(road_segment)
         return segmented_road_network
 
     if check_split(segment_after_split, meter):
-        if len(segment_after_split['geometry']['coordinates']) <= min_gps:
+        if len(segment_after_split["geometry"]["coordinates"]) <= min_gps:
             segmented_road_network.append(road_segment)
             return segmented_road_network
         segmented_road_network = split_segment(segment_after_split, meter, segmented_road_network, min_gps)
     else:
-        if len(segment_after_split['geometry']['coordinates']) >= min_gps:
+        if len(segment_after_split["geometry"]["coordinates"]) >= min_gps:
             segmented_road_network.append(segment_after_split)
     return segmented_road_network
 
@@ -51,7 +51,7 @@ def check_split(road_segment, max_distance):
     :return: True or False, True meaning the road segment should be split
     """
 
-    if (calculate_road_length_simple(road_segment['geometry']['coordinates'])) > max_distance:
+    if (calculate_road_length_simple(road_segment["geometry"]["coordinates"])) > max_distance:
         return True
     else:
         return False
@@ -81,13 +81,13 @@ def segment_network(road_network, len_road_network, max_distance, min_gps):
     """
     segmented_road_network = []
     for road_segment in range(0, len_road_network):
-        if len(road_network['features'][road_segment]['geometry']['coordinates']) > min_gps:
-            if check_split(road_network['features'][road_segment], max_distance):
-                split_roads = split_segment(road_network['features'][road_segment],
+        if len(road_network["features"][road_segment]["geometry"]["coordinates"]) > min_gps:
+            if check_split(road_network["features"][road_segment], max_distance):
+                split_roads = split_segment(road_network["features"][road_segment],
                                             max_distance, [], min_gps)
                 if split_roads is not None:
                     for new_road in split_roads:
                         segmented_road_network.append(new_road)
             else:
-                segmented_road_network.append(road_network['features'][road_segment])
+                segmented_road_network.append(road_network["features"][road_segment])
     return segmented_road_network

--- a/backend/data/road_segmenting/tests/test_segmenting.py
+++ b/backend/data/road_segmenting/tests/test_segmenting.py
@@ -10,7 +10,7 @@ class TestSegmenting(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.kommune = 5001
-        cls.vegref = 'kg'
+        cls.vegref = "kg"
         cls.max_segment_length = 100
         cls.min_segment_length = 2
         network = vegnet_to_geojson(cls.kommune, cls.vegref)
@@ -52,10 +52,10 @@ class TestSegmenting(unittest.TestCase):
         error_message = "These segments have less than " \
                         + str(self.min_segment_length) + " GPS points \n"
         for road in self.split_segments:
-            if len(road['geometry']['coordinates']) < self.min_segment_length:
+            if len(road["geometry"]["coordinates"]) < self.min_segment_length:
                 count += 1
-                error_message += "Veglenkeid: " + str(road['properties']['veglenkeid']) + ", coordinates: " + \
-                                 str(road['geometry']['coordinates']) + "\n"
+                error_message += "Veglenkeid: " + str(road["properties"]["veglenkeid"]) + ", coordinates: " + \
+                                 str(road["geometry"]["coordinates"]) + "\n"
         self.assertLess(count, 1, (count, "errors:", error_message))
 
     def test_calculate_road_length(self):
@@ -68,19 +68,19 @@ class TestSegmenting(unittest.TestCase):
         errors = 0
         error_message = "Issues are with these segments: \n"
         for key, values in self.road_net.items():
-            if key != 'crs':
+            if key != "crs":
                 for i in range(0, self.count):
-                    road = self.road_net['features'][i]
-                    length_actual = road['properties']['strekningslengde']
-                    length_original = calculate_road_length(road['geometry']['coordinates'], 1000, False)[1]
+                    road = self.road_net["features"][i]
+                    length_actual = road["properties"]["strekningslengde"]
+                    length_original = calculate_road_length(road["geometry"]["coordinates"], 1000, False)[1]
                     road_segmented = split_segment(road, self.max_segment_length, [], self.min_segment_length)
 
                     length_new = 0
                     for segment in road_segmented:
-                        length_new += calculate_road_length(segment['geometry']['coordinates'], 1000, False)[1]
+                        length_new += calculate_road_length(segment["geometry"]["coordinates"], 1000, False)[1]
                     if abs(length_actual - length_new) > margin:
                         errors += 1
-                        error_message += "Veglenkeid: " + str(road['properties']['veglenkeid']) + \
+                        error_message += "Veglenkeid: " + str(road["properties"]["veglenkeid"]) + \
                                          ", actual length: " + str(length_actual) + ", original: " + \
                                          str(length_original) + ", new:" + str(length_new) + "\n"
         self.assertLess(errors, 1, (errors, "errors:", error_message))
@@ -93,19 +93,19 @@ class TestSegmenting(unittest.TestCase):
         errors = 0
         error_message = "Issues are with these " + str(errors) + " links: \n"
         for key, values in self.road_net.items():
-            if key != 'crs':
+            if key != "crs":
                 for i in range(0, self.count):
-                    road = self.road_net['features'][i]
+                    road = self.road_net["features"][i]
                     road_segmented = split_segment(road, self.max_segment_length, [], self.min_segment_length)
 
                     for segment in range(1, len(road_segmented)):
-                        prev = road_segmented[segment-1]['geometry']['coordinates']
+                        prev = road_segmented[segment-1]["geometry"]["coordinates"]
                         end_prev = prev[len(prev)-1]
-                        start_curr = road_segmented[segment]['geometry']['coordinates'][0]
+                        start_curr = road_segmented[segment]["geometry"]["coordinates"][0]
 
                         if end_prev != start_curr:
                             errors += 1
-                            error_message += "Veglenkeid: " + str(road['properties']['veglenkeid']) + \
+                            error_message += "Veglenkeid: " + str(road["properties"]["veglenkeid"]) + \
                                 ", does not start at " + str(end_prev) + ", instead: " + str(start_curr) + "\n"
         self.assertLess(errors, 1, (errors, "errors:", error_message))
 
@@ -121,7 +121,7 @@ class TestSegmenting(unittest.TestCase):
         margin = 50
         errors = 0
         for road in self.split_segments:
-            if (road['properties']['strekningslengde'] - self.max_segment_length) > margin:
+            if (road["properties"]["strekningslengde"] - self.max_segment_length) > margin:
                 errors += 1
 
         self.assertLess(errors, 50, (errors, "roads exceeded the road length limit"))
@@ -133,11 +133,11 @@ class TestSegmenting(unittest.TestCase):
         """
         errors = 0
         for road in self.split_segments:
-            if road['properties']['strekningslengde'] < 0:
+            if road["properties"]["strekningslengde"] < 0:
                 errors += 1
 
         self.assertLess(errors, 1, ("This many segments are under 0 meters:", errors))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/backend/data/road_segmenting/tests/test_segmenting.py
+++ b/backend/data/road_segmenting/tests/test_segmenting.py
@@ -138,6 +138,19 @@ class TestSegmenting(unittest.TestCase):
 
         self.assertLess(errors, 1, ("This many segments are under 0 meters:", errors))
 
+    def test_duplicate_segments(self):
+        """
+        Test if there are duplicate segments
+        """
+        length = len(self.split_segments)
+        start_index = 0
+        for i in range(length):
+            for y in range(start_index, length):
+                if i != y:
+                    self.assertNotEqual(self.split_segments[i]["geometry"]["coordinates"],
+                                        self.split_segments[y]["geometry"]["coordinates"])
+            start_index += 1
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Description
<!--- Describe your changes in detail -->
There was an unnecessary for loop in segment_network that caused the segmenting to happen twice.

Also replaced single quotation marks with double quotation marks in the road segmenting files (but not the nvdb files)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To save space in database and to make the segmenting methods correct.
Resolves #148 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, tests ran to see how -->
<!--- your change affects other areas of the code, etc. -->
Made a test in data/tests that loops through segments and asserts that there are no duplicates.

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
