### PR TITLE
Added test coverage, README badges, removed webpack loader requirement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ roadnet.gjson
 .pytest_cache/
 
 .coverage
+coverage.xml

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ nvdbapi-clientinfo.json
 roadnet.gjson
 
 .pytest_cache/
+
+.coverage

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
 script:
   - flake8 apps/api apps/data
   - isort -c
-  - py.test --cov
+  - py.test --cov=apps
 after_success:
   - bash < (curl -s https://codecov.io/bash)
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,8 @@ env:
 script:
   - flake8 apps/api apps/data
   - isort -c
-  - py.test
+  - py.test --cov
+after_success:
+  - bash < (curl -s https://codecov.io/bash)
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ lint:
 	docker-compose run --rm $(BACKEND_SERVICE_NAME) isort -c
 
 test:
-	docker-compose run --rm $(BACKEND_SERVICE_NAME) py.test
+	docker-compose run --rm $(BACKEND_SERVICE_NAME) py.test --cov=apps

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # VAPI - Vegnett API
 
+[![Build Status](https://travis-ci.org/IT2901-24-2018/vapi.svg?branch=dev)](https://travis-ci.org/IT2901-24-2018/vapi) [![codecov](https://codecov.io/gh/IT2901-24-2018/vapi/branch/dev/graph/badge.svg)](https://codecov.io/gh/IT2901-24-2018/vapi)
+
 Vapi is an API that gathers Norways digital roadnet, then segments it into reasonably sized road segments. We also accept input for production data related to road condition influences like weather and maintenance (snow plowing, gravelling, salting). This data is mapped to the road segments, and outputted as a RESTful API.
 
 Vapi was built by a team of seven students in their sixth semester of the Bachelor’s in Informatics programme at [NTNU](https://www.ntnu.edu/), as a part of the course [IT2901](https://www.ntnu.edu/studies/courses/IT2901) - Informatics Project II, colloquially known as the bachelor's thesis. Vapi was developed for the [Norwegian Public Roads Administration](https://www.vegvesen.no/en/home).

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ astroid==1.6.1
 attrs==17.4.0
 certifi==2018.1.18
 chardet==3.0.4
+codecov==2.0.15
 coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ coreapi==2.3.3
 coreschema==0.0.4
 coverage==4.5.1
 Django==2.0.2
-django-webpack-loader==0.5.0
 djangorestframework==3.7.7
 flake8==3.5.0
 geojson==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ certifi==2018.1.18
 chardet==3.0.4
 coreapi==2.3.3
 coreschema==0.0.4
+coverage==4.5.1
 Django==2.0.2
 django-webpack-loader==0.5.0
 djangorestframework==3.7.7
@@ -24,6 +25,7 @@ pycodestyle==2.3.1
 pyflakes==1.6.0
 pylint==1.8.2
 pytest==3.5.0
+pytest-cov==2.5.1
 pytest-django==3.2.1
 pytz==2018.3
 requests==2.18.4

--- a/vapi/settings.py
+++ b/vapi/settings.py
@@ -64,7 +64,6 @@ INSTALLED_APPS = [
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
-    'webpack_loader',
     'rest_framework',
     'api',
 ]


### PR DESCRIPTION
Title sums it up. Code coverage will be printed out when running tests, and Travis will push the coverage to [coverage.io](https://codecov.io/gh/IT2901-24-2018/vapi/).