### PR TITLE
Fix error in prod data view

### DIFF
--- a/apps/api/views.py
+++ b/apps/api/views.py
@@ -128,13 +128,11 @@ class ProductionDataViewSet(viewsets.ModelViewSet):
         # Check if the serializer is valid and takes the necessary actions
         if serializer.is_valid():
             # Handle weather data when adding new production data
-            weather.handle_prod_weather_overlap(serializer.data)
+            weather.handle_prod_weather_overlap(serializer.validated_data)
             serializer.save()
-            # headers = self.get_success_headers(serializer.data)
             return Response(
                 "{} row(s) added".format(len(serializer.data)),
                 status=status.HTTP_201_CREATED,
-                # headers=headers
             )
 
         # If not valid return error


### PR DESCRIPTION
There was an error in the production data viewset.
Changed the weather handle overlap parameter from serializer.data to serializer.vaidated_data
serializer.data should not be used to access data before saving.